### PR TITLE
fix(api): handle click with custom components

### DIFF
--- a/lib/services/core/index.d.ts
+++ b/lib/services/core/index.d.ts
@@ -26,6 +26,7 @@ type onRenderComponent =
       defaultComponent: HTMLElement,
       componentType: "form",
       formComponentType: "submit",
+      handleClick: () => Promise<void>,
       label: string,
     ) => HTMLElement | undefined)
   | ((
@@ -38,6 +39,7 @@ type onRenderComponent =
       defaultComponent: HTMLElement,
       componentType: "oidcButton",
       provider: string,
+      handleClick: () => Promise<void>,
       id: string,
       url: string,
     ) => HTMLElement | undefined)

--- a/lib/services/core/ui/messageParser/__tests__/form.test.js
+++ b/lib/services/core/ui/messageParser/__tests__/form.test.js
@@ -96,6 +96,7 @@ describe("when it is the 'login' type", () => {
           expect.any(HTMLButtonElement),
           "form",
           "submit",
+          expect.any(Function),
           "Login mock",
         );
       });
@@ -188,6 +189,7 @@ describe("when it is the 'login' type", () => {
             expect.any(HTMLButtonElement),
             "form",
             "submit",
+            expect.any(Function),
             "Login mock",
           );
         });
@@ -311,6 +313,7 @@ describe("when it is the 'login' type", () => {
             expect.any(HTMLButtonElement),
             "form",
             "submit",
+            expect.any(Function),
             "Login mock",
           );
         });
@@ -393,6 +396,7 @@ describe("when it is the 'login' type", () => {
             expect.any(HTMLButtonElement),
             "form",
             "submit",
+            expect.any(Function),
             "Custom login",
           );
         });
@@ -476,6 +480,7 @@ describe("when it is the 'login' type", () => {
             expect.any(HTMLButtonElement),
             "form",
             "submit",
+            expect.any(Function),
             "Login mock",
           );
         });
@@ -528,6 +533,7 @@ describe("when it is the 'login' type", () => {
             expect.any(HTMLButtonElement),
             "form",
             "submit",
+            expect.any(Function),
             "Login mock",
           );
         });
@@ -579,6 +585,7 @@ describe("when it is the 'login' type", () => {
             expect.any(HTMLButtonElement),
             "form",
             "submit",
+            expect.any(Function),
             "Custom login",
           );
         });
@@ -650,6 +657,7 @@ describe("when it is the 'registration' type", () => {
               expect.any(HTMLButtonElement),
               "form",
               "submit",
+              expect.any(Function),
               "Register mock",
             );
           });
@@ -773,6 +781,7 @@ describe("when it is the 'registration' type", () => {
               expect.any(HTMLButtonElement),
               "form",
               "submit",
+              expect.any(Function),
               "Register mock",
             );
           });
@@ -855,6 +864,7 @@ describe("when it is the 'registration' type", () => {
               expect.any(HTMLButtonElement),
               "form",
               "submit",
+              expect.any(Function),
               "Custom register",
             );
           });
@@ -1025,6 +1035,7 @@ describe("when it is the 'registration' type", () => {
           expect.any(HTMLButtonElement),
           "form",
           "submit",
+          expect.any(Function),
           "Agree & Register mock",
         );
         expect(createRenderComponentCallback).nthCalledWith(
@@ -1142,6 +1153,7 @@ describe("when it is the 'registration' type", () => {
           expect.any(HTMLButtonElement),
           "form",
           "submit",
+          expect.any(Function),
           "Register mock",
         );
       });
@@ -1213,6 +1225,7 @@ describe("when it is the 'registration' type", () => {
           expect.any(HTMLButtonElement),
           "form",
           "submit",
+          expect.any(Function),
           "Register mock",
         );
       });
@@ -1281,6 +1294,7 @@ describe("when it is the 'registration' type", () => {
           expect.any(HTMLButtonElement),
           "form",
           "submit",
+          expect.any(Function),
           "Custom register",
         );
       });

--- a/lib/services/core/ui/messageParser/__tests__/oidc.test.js
+++ b/lib/services/core/ui/messageParser/__tests__/oidc.test.js
@@ -1,0 +1,228 @@
+const oidc = require("../oidc");
+const { oidcButtonUI } = require("../../components/buttons");
+const { createRenderComponentCallback } = require("../../../utils/helpers");
+const oidcSetup = require("../../../lib/login/oidcSetup");
+
+jest.mock("../../components/buttons");
+jest.mock("../../../lib/login/oidcSetup");
+jest.mock("../../../utils/helpers", () => {
+  const originalModule = jest.requireActual("../../../utils/helpers");
+  return {
+    ...originalModule,
+    createRenderComponentCallback: jest.fn(),
+  };
+});
+
+let props;
+
+beforeEach(() => {
+  jest.resetAllMocks();
+
+  const mockedButton = document.createElement("button");
+  oidcButtonUI.mockImplementation(() => mockedButton);
+
+  createRenderComponentCallback.mockImplementation((...args) => {
+    const originalModule = jest.requireActual("../../../utils/helpers");
+    return originalModule.createRenderComponentCallback(...args);
+  });
+
+  props = {
+    context: {
+      "@id": "12345",
+      prv: "indykite.id",
+      url: "https://example.com",
+    },
+    htmlContainer: document.createElement("div"),
+    redirectUri: "https:/address.com/to/redirect",
+  };
+});
+
+describe("when provider has a name", () => {
+  beforeEach(() => {
+    props.context.name = "indykite.me";
+  });
+
+  describe("when loginApp prop is not specified", () => {
+    describe("when onRenderComponent prop is used", () => {
+      beforeEach(() => {
+        const onRenderComponent = jest.fn();
+        props.onRenderComponent = onRenderComponent;
+      });
+
+      describe("when onRenderComponent does not return a new component", () => {
+        beforeEach(() => {
+          return oidc(props);
+        });
+
+        it("creates a correct default button", () => {
+          expect(oidcButtonUI).toBeCalledTimes(1);
+          expect(oidcButtonUI).toBeCalledWith({
+            id: "IKUISDK-btn-oidc-indykite-me",
+            data: props.context,
+            onClick: expect.any(Function),
+          });
+        });
+
+        it("appends the correct component to the container", () => {
+          expect(createRenderComponentCallback).toBeCalledTimes(1);
+          expect(createRenderComponentCallback).toBeCalledWith(
+            props.onRenderComponent,
+            oidcButtonUI.mock.results[0].value,
+            "oidcButton",
+            props.context.prv,
+            expect.any(Function),
+            props.context["@id"],
+            props.context.url,
+          );
+
+          // Default onClick handler should be passed to the onRenderComponent function
+          expect(oidcButtonUI.mock.calls[0][0].onClick).toBe(
+            createRenderComponentCallback.mock.calls[0][4],
+          );
+
+          expect(props.htmlContainer.childElementCount).toBe(1);
+          expect(props.htmlContainer.children.item(0)).toBe(oidcButtonUI.mock.results[0].value);
+        });
+
+        describe("when the button is clicked", () => {
+          beforeEach(() => {
+            oidcButtonUI.mock.calls[0][0].onClick();
+          });
+
+          it("calls oidcSetup with correct parameters", () => {
+            expect(oidcSetup).toBeCalledTimes(1);
+            expect(oidcSetup).toBeCalledWith({
+              id: "12345",
+              redirectUri: "https:/address.com/to/redirect",
+            });
+          });
+        });
+      });
+
+      describe("when onRenderComponent returns a new component", () => {
+        beforeEach(() => {
+          props.onRenderComponent.mockImplementation(
+            (defaultButton, componentType, provider, clickHanlder) => {
+              const customButton = document.createElement("button");
+              customButton.classList.add("custom");
+              customButton.addEventListener("click", clickHanlder);
+              return customButton;
+            },
+          );
+
+          return oidc(props);
+        });
+
+        it("appends the correct component to the container", () => {
+          expect(props.htmlContainer.childElementCount).toBe(1);
+          expect(props.htmlContainer.children.item(0)).toBe(
+            props.onRenderComponent.mock.results[0].value,
+          );
+        });
+
+        describe("when the button is clicked", () => {
+          beforeEach(() => {
+            props.onRenderComponent.mock.results[0].value.click();
+          });
+
+          it("calls oidcSetup with correct parameters", () => {
+            expect(oidcSetup).toBeCalledTimes(1);
+            expect(oidcSetup).toBeCalledWith({
+              id: "12345",
+              redirectUri: "https:/address.com/to/redirect",
+            });
+          });
+        });
+      });
+    });
+
+    describe("when onRenderComponent prop is not used", () => {
+      beforeEach(() => {
+        return oidc(props);
+      });
+
+      describe("when the button is clicked", () => {
+        beforeEach(() => {
+          oidcButtonUI.mock.calls[0][0].onClick();
+        });
+
+        it("calls oidcSetup with correct parameters", () => {
+          expect(oidcSetup).toBeCalledTimes(1);
+          expect(oidcSetup).toBeCalledWith({
+            id: "12345",
+            redirectUri: "https:/address.com/to/redirect",
+          });
+        });
+      });
+    });
+  });
+
+  describe("when loginApp prop is specified", () => {
+    beforeEach(() => {
+      props.loginApp = {
+        12345: "custom-app",
+      };
+      return oidc(props);
+    });
+
+    it("creates a correct default button", () => {
+      expect(oidcButtonUI).toBeCalledTimes(1);
+      expect(oidcButtonUI).toBeCalledWith({
+        id: "IKUISDK-btn-oidc-indykite-me",
+        data: props.context,
+        onClick: expect.any(Function),
+      });
+    });
+
+    it("appends the correct component to the container", () => {
+      expect(createRenderComponentCallback).toBeCalledTimes(1);
+      expect(createRenderComponentCallback).toBeCalledWith(
+        props.onRenderComponent,
+        oidcButtonUI.mock.results[0].value,
+        "oidcButton",
+        props.context.prv,
+        expect.any(Function),
+        props.context["@id"],
+        props.context.url,
+      );
+
+      // Default onClick handler should be passed to the onRenderComponent function
+      expect(oidcButtonUI.mock.calls[0][0].onClick).toBe(
+        createRenderComponentCallback.mock.calls[0][4],
+      );
+
+      expect(props.htmlContainer.childElementCount).toBe(1);
+      expect(props.htmlContainer.children.item(0)).toBe(oidcButtonUI.mock.results[0].value);
+    });
+
+    describe("when the button is clicked", () => {
+      beforeEach(() => {
+        oidcButtonUI.mock.calls[0][0].onClick();
+      });
+
+      it("calls oidcSetup with correct parameters", () => {
+        expect(oidcSetup).toBeCalledTimes(1);
+        expect(oidcSetup).toBeCalledWith({
+          id: "12345",
+          redirectUri: "https:/address.com/to/redirect",
+          loginApp: "custom-app",
+        });
+      });
+    });
+  });
+});
+
+describe("when provider does not have a name", () => {
+  beforeEach(() => {
+    return oidc(props);
+  });
+
+  it("creates a correct default button", () => {
+    expect(oidcButtonUI).toBeCalledTimes(1);
+    expect(oidcButtonUI).toBeCalledWith({
+      id: "IKUISDK-btn-oidc-indykite-id",
+      data: props.context,
+      onClick: expect.any(Function),
+    });
+  });
+});

--- a/lib/services/core/ui/messageParser/form.js
+++ b/lib/services/core/ui/messageParser/form.js
@@ -170,37 +170,45 @@ const form = ({
       (termsAngAgreementHtmlString
         ? defaultLabels.agreeAndRegisterButton
         : defaultLabels.registerButton);
+    const clickHandler = (e) => {
+      e.preventDefault();
+      // check if property validatePassword exists and is a function
+      if (typeof validatePassword === "function") {
+        const psswrdInput = form.querySelector("input[type='password']");
+        if (psswrdInput && validatePassword(psswrdInput.value) !== true) {
+          //abort if validatePassword not returns true
+          // IndyRiot doesn't want to have errors
+          // handleError({
+          //   label: "uisdk.general.password_validation",
+          // });
+          return;
+        }
+      }
+      handleRegister({
+        id: context["@id"],
+        onSuccessCallback,
+        emailValueParam: null,
+        passwordValueParam: null,
+      }).catch((err) => {
+        if (typeof err === "object" && err["~error"]) {
+          handleError(err["~error"]);
+        }
+      });
+    };
     const button = primaryButtonUI({
       id: elementIds.submitRegisterBtn,
-      onClick: (e) => {
-        e.preventDefault();
-        // check if property validatePassword exists and is a function
-        if (typeof validatePassword === "function") {
-          const psswrdInput = form.querySelector("input[type='password']");
-          if (psswrdInput && validatePassword(psswrdInput.value) !== true) {
-            //abort if validatePassword not returns true
-            // IndyRiot doesn't want to have errors
-            // handleError({
-            //   label: "uisdk.general.password_validation",
-            // });
-            return;
-          }
-        }
-        handleRegister({
-          id: context["@id"],
-          onSuccessCallback,
-          emailValueParam: null,
-          passwordValueParam: null,
-        }).catch((err) => {
-          if (typeof err === "object" && err["~error"]) {
-            handleError(err["~error"]);
-          }
-        });
-      },
+      onClick: clickHandler,
       label: buttonLabel,
     });
     form.appendChild(
-      createRenderComponentCallback(onRenderComponent, button, "form", "submit", buttonLabel),
+      createRenderComponentCallback(
+        onRenderComponent,
+        button,
+        "form",
+        "submit",
+        clickHandler,
+        buttonLabel,
+      ),
     );
 
     if (termsAngAgreementHtmlString) {
@@ -219,25 +227,33 @@ const form = ({
     }
   } else {
     const buttonLabel = (customLabels && customLabels.loginButton) || defaultLabels.loginButton;
+    const clickHandler = (e) => {
+      e.preventDefault();
+      handleLogin({
+        id: context["@id"],
+        onSuccessCallback,
+        emailValueParam: null,
+        passwordValueParam: null,
+      }).catch((err) => {
+        if (typeof err === "object" && err["~error"]) {
+          handleError(err["~error"]);
+        }
+      });
+    };
     const button = primaryButtonUI({
       id: elementIds.submitLoginBtn,
-      onClick: (e) => {
-        e.preventDefault();
-        handleLogin({
-          id: context["@id"],
-          onSuccessCallback,
-          emailValueParam: null,
-          passwordValueParam: null,
-        }).catch((err) => {
-          if (typeof err === "object" && err["~error"]) {
-            handleError(err["~error"]);
-          }
-        });
-      },
+      onClick: clickHandler,
       label: buttonLabel,
     });
     form.appendChild(
-      createRenderComponentCallback(onRenderComponent, button, "form", "submit", buttonLabel),
+      createRenderComponentCallback(
+        onRenderComponent,
+        button,
+        "form",
+        "submit",
+        clickHandler,
+        buttonLabel,
+      ),
     );
   }
 

--- a/lib/services/core/ui/messageParser/oidc.js
+++ b/lib/services/core/ui/messageParser/oidc.js
@@ -23,17 +23,18 @@ const { oidcButtonUI } = require("../components/buttons");
  */
 const oidc = ({ context, htmlContainer, onRenderComponent, redirectUri, loginApp = {} }) => {
   const elementIds = getElementIds();
+  const clickHandler = async () => {
+    const id = context["@id"];
+    const params = { id, redirectUri };
+    if (loginApp[id]) {
+      params.loginApp = loginApp[id];
+    }
+    return oidcSetup(params);
+  };
   const button = oidcButtonUI({
     id: elementIds.oidcBtnPrefix + createIdFromString(context.name || context.prv),
     data: context,
-    onClick: () => {
-      const id = context["@id"];
-      const params = { id, redirectUri };
-      if (loginApp[id]) {
-        params.loginApp = loginApp[id];
-      }
-      oidcSetup(params);
-    },
+    onClick: clickHandler,
   });
   htmlContainer.appendChild(
     createRenderComponentCallback(
@@ -41,6 +42,7 @@ const oidc = ({ context, htmlContainer, onRenderComponent, redirectUri, loginApp
       button,
       "oidcButton",
       context.prv,
+      clickHandler,
       context["@id"],
       context.url,
     ),


### PR DESCRIPTION
When you use `onRenderComponent` function to replace an OIDC button
with your own, there was not an easy way how to handle the click
event. Now the default event is passed to the function so you can
easily call it.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->

# Description

<!-- Please provide a description of the change here. -->

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

# Checklist

- [ ] `make test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](./doc/guides/commit-message.md#commit-message-guidelines)

## CHANGELOG

<!-- Please provide a brief description of changes here. -->
<!-- - [FIX] Fix a dirty bug -->

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
