### PR TITLE
Allow to login with otp token

### DIFF
--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -4,3 +4,4 @@ coverage:
       default:
         target: 70% # the required coverage value
         threshold: 1% # the leniency in hitting the target
+    patch: off

--- a/README.md
+++ b/README.md
@@ -395,6 +395,10 @@ console.log(data.expiration_time); // Timestamp
 console.log(data.expires_in); // In x seconds
 ```
 
+> If a user was invited to your system and he has a reference ID from his invitation email, you should pass the reference ID to
+> the loginSetup function (`IKUIUserAPI.loginSetup({ otpToken: "referenceID" })`) so that the application is able to connect
+> the logged in user with the invited one.
+
 #### Register `IKUIUserAPI.register("username", "Passwd")`
 
 Calling this function with valid username and password parameters returns promise which is resolved and returns access tokens or rejected and returns error info.
@@ -458,6 +462,10 @@ return (
   </div>
 );
 ```
+
+> If a user was invited to your system and he has a reference ID from his invitation email, you should pass the reference ID to
+> the registerSetup function (`IKUIUserAPI.registerSetup({ otpToken: "referenceID" })`) so that the application is able to connect
+> the registered user with the invited one.
 
 #### ~~Logout the user `IKUIUserAPI.logoutCurrentUser()`~~
 

--- a/lib/services/core/constants.js
+++ b/lib/services/core/constants.js
@@ -1,3 +1,9 @@
+/**
+ * @type {{
+ *   register: "register",
+ *   login: "customer"
+ * }}
+ */
 const flowTypes = {
   register: "register",
   login: "customer",

--- a/lib/services/core/index.d.ts
+++ b/lib/services/core/index.d.ts
@@ -191,8 +191,11 @@ type sendNewPassword = (
   newPassword: string,
 ) => Promise<DataTokenResponseType>;
 
-type loginSetup = () => Promise<LoginSetupDataType>;
-type registerSetup = () => Promise<LoginSetupDataType>;
+type setupRequestConfig = {
+  otpToken?: string;
+};
+type loginSetup = (config?: setupRequestConfig) => Promise<LoginSetupDataType>;
+type registerSetup = (config?: setupRequestConfig) => Promise<LoginSetupDataType>;
 
 interface IKUIUserAPI {
   isAuthenticated: isAuthenticated;

--- a/lib/services/core/lib/common/__tests__/setupRequest.test.js
+++ b/lib/services/core/lib/common/__tests__/setupRequest.test.js
@@ -143,110 +143,19 @@ describe("when a request is created", () => {
     });
 
     describe('when the response type is "success"', () => {
-      describe("when message contains a verifier token", () => {
-        const message = {
-          data: {
-            "@type": "success",
-            verifier: "verifier-token",
-          },
-        };
-        let returnedValue;
-
-        beforeEach(async () => {
-          sendRequest.mockImplementation(() => message);
-          returnedValue = await setupRequest();
-        });
-
-        it("returns data of the received message", () => {
-          expect(returnedValue).toBe(message.data);
-        });
-
-        it("sends a correct request", () => {
-          expect(sendRequest).toBeCalledTimes(1);
-          expect(sendRequest.mock.calls[0][0]).toBe("http://www.example.com/auth/12345");
-          expect(sendRequest.mock.calls[0][1].toLowerCase()).toBe("post");
-          expect(sendRequest.mock.calls[0][2]).toEqual({
-            cc: "code-challenge-token",
-            "~arg": {
-              flow: "customer",
+      describe("when request does not have an 'otpToken'", () => {
+        describe("when message contains a verifier token", () => {
+          const message = {
+            data: {
+              "@type": "success",
+              verifier: "verifier-token",
             },
-            "~tenant": "tenant-id",
-          });
-          expect(sendRequest.mock.calls[0][3]).toEqual({
-            actionName: "setup",
-            headers: {
-              authorization: "Bearer valid-token",
-            },
-          });
-        });
+          };
+          let returnedValue;
 
-        it("does not set neither cv nor thread id", () => {
-          expect(setCv).not.toBeCalled();
-          expect(setThreadId).not.toBeCalled();
-        });
-      });
-
-      describe("when message does not contain a verifier token", () => {
-        const message = {
-          data: {
-            "@type": "success",
-            "~thread": {
-              thid: "thread-id",
-            },
-          },
-        };
-        let returnedValue;
-
-        describe("when the access token can not be retrieved", () => {
-          beforeEach(async () => {
-            getValidAccessToken.mockImplementation(() => Promise.reject(new Error()));
-            sendRequest.mockImplementation(() => message);
-            returnedValue = await setupRequest();
-          });
-
-          it("prints a debug message into console", () => {
-            expect(console.debug).toBeCalledTimes(1);
-            expect(console.debug.mock.calls[0][0]).toBe(
-              "No access token found. Setup request will continue without including access token in headers.",
-            );
-          });
-
-          it("returns data of the received message", () => {
-            expect(returnedValue).toBe(message.data);
-          });
-
-          it("sends a correct request", () => {
-            expect(sendRequest).toBeCalledTimes(1);
-            expect(sendRequest.mock.calls[0][0]).toBe("http://www.example.com/auth/12345");
-            expect(sendRequest.mock.calls[0][1].toLowerCase()).toBe("post");
-            expect(sendRequest.mock.calls[0][2]).toEqual({
-              cc: "code-challenge-token",
-              "~arg": {
-                flow: "customer",
-              },
-              "~tenant": "tenant-id",
-            });
-            expect(sendRequest.mock.calls[0][3]).toEqual({
-              actionName: "setup",
-            });
-          });
-
-          it("sets cv and thread id", () => {
-            expect(setCv).toBeCalled();
-            expect(setCv.mock.calls[0]).toEqual(["code-verifier-token"]);
-            expect(setThreadId).toBeCalled();
-            expect(setThreadId.mock.calls[0]).toEqual(["thread-id"]);
-          });
-        });
-
-        describe("when the access token can be retrieved", () => {
           beforeEach(async () => {
             sendRequest.mockImplementation(() => message);
             returnedValue = await setupRequest();
-          });
-
-          it("does not print a debug message into console", () => {
-            expect(console.debug).toBeCalledTimes(0);
           });
 
           it("returns data of the received message", () => {
@@ -272,12 +181,143 @@ describe("when a request is created", () => {
             });
           });
 
-          it("sets cv and thread id", () => {
-            expect(setCv).toBeCalled();
-            expect(setCv.mock.calls[0]).toEqual(["code-verifier-token"]);
-            expect(setThreadId).toBeCalled();
-            expect(setThreadId.mock.calls[0]).toEqual(["thread-id"]);
+          it("does not set neither cv nor thread id", () => {
+            expect(setCv).not.toBeCalled();
+            expect(setThreadId).not.toBeCalled();
           });
+        });
+
+        describe("when message does not contain a verifier token", () => {
+          const message = {
+            data: {
+              "@type": "success",
+              "~thread": {
+                thid: "thread-id",
+              },
+            },
+          };
+          let returnedValue;
+
+          describe("when the access token can not be retrieved", () => {
+            beforeEach(async () => {
+              getValidAccessToken.mockImplementation(() => Promise.reject(new Error()));
+              sendRequest.mockImplementation(() => message);
+              returnedValue = await setupRequest();
+            });
+
+            it("prints a debug message into console", () => {
+              expect(console.debug).toBeCalledTimes(1);
+              expect(console.debug.mock.calls[0][0]).toBe(
+                "No access token found. Setup request will continue without including access token in headers.",
+              );
+            });
+
+            it("returns data of the received message", () => {
+              expect(returnedValue).toBe(message.data);
+            });
+
+            it("sends a correct request", () => {
+              expect(sendRequest).toBeCalledTimes(1);
+              expect(sendRequest.mock.calls[0][0]).toBe("http://www.example.com/auth/12345");
+              expect(sendRequest.mock.calls[0][1].toLowerCase()).toBe("post");
+              expect(sendRequest.mock.calls[0][2]).toEqual({
+                cc: "code-challenge-token",
+                "~arg": {
+                  flow: "customer",
+                },
+                "~tenant": "tenant-id",
+              });
+              expect(sendRequest.mock.calls[0][3]).toEqual({
+                actionName: "setup",
+              });
+            });
+
+            it("sets cv and thread id", () => {
+              expect(setCv).toBeCalled();
+              expect(setCv.mock.calls[0]).toEqual(["code-verifier-token"]);
+              expect(setThreadId).toBeCalled();
+              expect(setThreadId.mock.calls[0]).toEqual(["thread-id"]);
+            });
+          });
+
+          describe("when the access token can be retrieved", () => {
+            beforeEach(async () => {
+              sendRequest.mockImplementation(() => message);
+              returnedValue = await setupRequest();
+            });
+
+            it("does not print a debug message into console", () => {
+              expect(console.debug).toBeCalledTimes(0);
+            });
+
+            it("returns data of the received message", () => {
+              expect(returnedValue).toBe(message.data);
+            });
+
+            it("sends a correct request", () => {
+              expect(sendRequest).toBeCalledTimes(1);
+              expect(sendRequest.mock.calls[0][0]).toBe("http://www.example.com/auth/12345");
+              expect(sendRequest.mock.calls[0][1].toLowerCase()).toBe("post");
+              expect(sendRequest.mock.calls[0][2]).toEqual({
+                cc: "code-challenge-token",
+                "~arg": {
+                  flow: "customer",
+                },
+                "~tenant": "tenant-id",
+              });
+              expect(sendRequest.mock.calls[0][3]).toEqual({
+                actionName: "setup",
+                headers: {
+                  authorization: "Bearer valid-token",
+                },
+              });
+            });
+
+            it("sets cv and thread id", () => {
+              expect(setCv).toBeCalled();
+              expect(setCv.mock.calls[0]).toEqual(["code-verifier-token"]);
+              expect(setThreadId).toBeCalled();
+              expect(setThreadId.mock.calls[0]).toEqual(["thread-id"]);
+            });
+          });
+        });
+      });
+
+      describe("when request has an 'otpToken'", () => {
+        const message = {
+          data: {
+            "@type": "success",
+            "~thread": {
+              thid: "thread-id",
+            },
+          },
+        };
+        let returnedValue;
+
+        beforeEach(async () => {
+          getValidAccessToken.mockImplementation(() => Promise.reject(new Error()));
+          sendRequest.mockImplementation(() => message);
+          returnedValue = await setupRequest({ otpToken: "otp-token" });
+        });
+
+        it("sends a correct request", () => {
+          expect(sendRequest).toBeCalledTimes(1);
+          expect(sendRequest.mock.calls[0][0]).toBe("http://www.example.com/auth/12345");
+          expect(sendRequest.mock.calls[0][1].toLowerCase()).toBe("post");
+          expect(sendRequest.mock.calls[0][2]).toEqual({
+            cc: "code-challenge-token",
+            "~token": "otp-token",
+          });
+          expect(sendRequest.mock.calls[0][3]).toEqual({
+            actionName: "setup",
+          });
+        });
+
+        it("sets cv and thread id", () => {
+          expect(setCv).toBeCalled();
+          expect(setCv.mock.calls[0]).toEqual(["code-verifier-token"]);
+          expect(setThreadId).toBeCalled();
+          expect(setThreadId.mock.calls[0]).toEqual(["thread-id"]);
         });
       });
     });

--- a/lib/services/core/lib/common/setupRequest.js
+++ b/lib/services/core/lib/common/setupRequest.js
@@ -8,7 +8,14 @@ const { flowTypes } = require("../../constants");
 const { getValidAccessToken } = require("../refresh");
 const { addAuthorizationTokenToHeaders, sendRequest } = require("../../utils/helpers");
 
-const setupRequest = async (config, flow = flowTypes.login) => {
+/**
+ * @param {{
+ *   otpToken?: string
+ * }} [config]
+ * @param {typeof flowTypes[keyof typeof flowTypes]} [flow]
+ * @returns
+ */
+const setupRequest = async (config = {}, flow = flowTypes.login) => {
   const { codeVerifier, codeChallenge } = getCodeVerifierAndChallenge();
 
   // Try to get access token from SDK store
@@ -26,11 +33,16 @@ const setupRequest = async (config, flow = flowTypes.login) => {
   try {
     const url = `${IDSDKConfig.getBaseUri()}/auth/${IDSDKConfig.getApplicationId()}`;
 
-    const data = {
-      cc: codeChallenge,
-      "~tenant": IDSDKConfig.getTenantId(),
-      "~arg": { flow },
-    };
+    const data = config.otpToken
+      ? {
+          cc: codeChallenge,
+          "~token": config.otpToken,
+        }
+      : {
+          cc: codeChallenge,
+          "~tenant": IDSDKConfig.getTenantId(),
+          "~arg": { flow },
+        };
     const oidcParams = getOidcOriginalParams();
 
     if (oidcParams && oidcParams.login_challenge) {
@@ -38,7 +50,7 @@ const setupRequest = async (config, flow = flowTypes.login) => {
     }
 
     // If there is token from SDK store - include in auth headers
-    const config =
+    const requestConfig =
       token && flow !== flowTypes.register
         ? {
             headers: addAuthorizationTokenToHeaders(token),
@@ -53,7 +65,7 @@ const setupRequest = async (config, flow = flowTypes.login) => {
         {
           actionName: "setup",
         },
-        config,
+        requestConfig,
       ),
     );
 

--- a/lib/services/core/lib/login/loginSetup.js
+++ b/lib/services/core/lib/login/loginSetup.js
@@ -3,7 +3,7 @@ const skipIfLogged = require("./skipIfLogged");
 
 /**
  * Initiates authentication flow. And returns setupData object. In case of OIDC flow automatically redirects when there is already valid session detected.
- * @param [config]
+ * @param {Parameters<typeof setupRequest>[0]} [config]
  * @returns {Promise<setupObject>} setupObject is then supposed to be passed as a third parameter to IKUIUserAPI.login("my@mail.com", "Passw0rd", setupObject)
  */
 const loginSetup = async (config) => {

--- a/lib/services/core/lib/register/registrationFormSetupRequest.js
+++ b/lib/services/core/lib/register/registrationFormSetupRequest.js
@@ -3,7 +3,7 @@ const { flowTypes } = require("../../constants");
 
 /**
  * Initiates authentication flow. And returns setupData object.
- * @param config
+ * @param {Parameters<typeof setupRequest>[0]} [config]
  * @returns {Promise<setupObject>}
  */
 const registrationFormSetupRequest = (config) => setupRequest(config, flowTypes.register);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->

# Description

<!-- Please provide a description of the change here. -->

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

# Checklist

- [ ] `make test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](./doc/guides/commit-message.md#commit-message-guidelines)

## CHANGELOG

<!-- Please provide a brief description of changes here. -->
<!-- - [FIX] Fix a dirty bug -->
- [AUTH] You can use reference ID from an invitation email as the otpToken in `IKUIUserAPI.loginSetup` and `IKUIUserAPI.registerSetup` functions.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
