### PR TITLE
Render input fields according to server configuration

### DIFF
--- a/lib/services/core/exports/IKUICore/__tests__/renderSetNewPasswordForm.test.js
+++ b/lib/services/core/exports/IKUICore/__tests__/renderSetNewPasswordForm.test.js
@@ -43,14 +43,11 @@ afterEach(() => {
 });
 
 describe("when setNewPasswordSetupRequest returns a list of registration options", () => {
-  const registrationOptionsResponse = {
-    "@type": "form",
-    fields: [],
-  };
+  const setNewPasswordSetupResponse = [];
 
   beforeEach(() => {
     setNewPasswordSetupRequest.mockImplementation(() =>
-      Promise.resolve(registrationOptionsResponse),
+      Promise.resolve(setNewPasswordSetupResponse),
     );
   });
 
@@ -76,6 +73,7 @@ describe("when setNewPasswordSetupRequest returns a list of registration options
         expect(newPasswordUI).toBeCalledWith({
           labels: props.labels,
           validatePassword: props.validatePassword,
+          fields: setNewPasswordSetupResponse,
         });
       });
 

--- a/lib/services/core/exports/IKUICore/renderSetNewPasswordForm.js
+++ b/lib/services/core/exports/IKUICore/renderSetNewPasswordForm.js
@@ -20,7 +20,7 @@ const renderSetNewPasswordForm = (props) => {
   throttleChecker("renderSetNewPasswordForm");
 
   return setNewPasswordSetupRequest(props.token)
-    .then(() => {
+    .then((fields) => {
       const renderElement = document.querySelector(props.renderElementSelector);
       if (!renderElement) {
         if (!props.renderElementSelector)
@@ -31,7 +31,11 @@ const renderSetNewPasswordForm = (props) => {
       }
       updateParentElement({
         parent: renderElement,
-        child: newPasswordUI({ labels: props.labels, validatePassword: props.validatePassword }),
+        child: newPasswordUI({
+          labels: props.labels,
+          validatePassword: props.validatePassword,
+          fields,
+        }),
       });
     })
     .catch((err) => {

--- a/lib/services/core/ui/__tests__/forgot-password.test.js
+++ b/lib/services/core/ui/__tests__/forgot-password.test.js
@@ -18,12 +18,27 @@ beforeEach(() => {
     return wrapper;
   });
 
-  props = {};
+  props = {
+    fields: [
+      {
+        "@id": "username",
+        "@type": "input",
+        autocomplete: true,
+        hint: "text",
+        maxlength: 128,
+        minlength: 8,
+        pattern: "^.{8,128}$",
+        placeholder: "username",
+        required: true,
+        "~ord": 0,
+      },
+    ],
+  };
 
   handleSendResetPasswordEmail.mockImplementation(() => Promise.resolve());
 });
 
-describe("when no props are specified", () => {
+describe("when fields prop is specified only", () => {
   /**
    * @type {HTMLElement}
    */
@@ -41,6 +56,7 @@ describe("when no props are specified", () => {
     expect(form.tagName.toLowerCase()).toBe("form");
     expect(form.className).toBe("forgotten-password-form");
 
+    expect(form.childElementCount).toBe(5);
     expect(form.children.item(0).tagName.toLowerCase()).toBe("label");
     expect(form.children.item(0).htmlFor).toBe("IKUISDK-reset-password-email");
     expect(form.children.item(0).innerText).toBe("Email Address");
@@ -161,6 +177,59 @@ describe("when custom labels are specified", () => {
     expect(form.children.item(3).tagName.toLowerCase()).toBe("hr");
     expect(form.children.item(4).children.item(0).innerText).toBe("Back to login");
     expect(form.children.item(4).children.item(0).href).toBe(
+      new URL("/login", location.href).toString(),
+    );
+  });
+});
+
+describe("when fields contains more entries", () => {
+  /**
+   * @type {HTMLElement}
+   */
+  let returnedValue;
+
+  beforeEach(() => {
+    props.fields.push({
+      "@id": "unknown",
+      "@type": "input",
+      autocomplete: true,
+      hint: "text",
+      maxlength: 128,
+      minlength: 8,
+      pattern: "^.{8,128}$",
+      placeholder: "unknown-placeholder",
+      required: true,
+      "~ord": 1,
+    });
+    returnedValue = forgotPasswordUI(props);
+  });
+
+  it("returns correct form", () => {
+    expect(returnedValue.className).toBe("mocked-wrapper");
+    const wrappedEl = returnedValue.children.item(0);
+    expect(wrappedEl.children.length).toBe(1);
+    const form = wrappedEl.children.item(0);
+    expect(form.tagName.toLowerCase()).toBe("form");
+    expect(form.className).toBe("forgotten-password-form");
+
+    expect(form.childElementCount).toBe(7);
+    expect(form.children.item(0).tagName.toLowerCase()).toBe("label");
+    expect(form.children.item(0).htmlFor).toBe("IKUISDK-reset-password-email");
+    expect(form.children.item(0).innerText).toBe("Email Address");
+    expect(form.children.item(1).tagName.toLowerCase()).toBe("input");
+    expect(form.children.item(1).id).toBe("IKUISDK-reset-password-email");
+    expect(form.children.item(2).tagName.toLowerCase()).toBe("label");
+    expect(form.children.item(2).htmlFor).toBe("unknown");
+    expect(form.children.item(2).innerText).toBe("unknown");
+    expect(form.children.item(3).tagName.toLowerCase()).toBe("input");
+    expect(form.children.item(3).id).toBe("unknown");
+    expect(form.children.item(4).tagName.toLowerCase()).toBe("button");
+    expect(form.children.item(4).type).toBe("submit");
+    expect(form.children.item(4).id).toBe("IKUISDK-reset-password-email-btn");
+    expect(form.children.item(4).innerText).toBe("Send password reset email");
+    expect(form.children.item(5).tagName.toLowerCase()).toBe("hr");
+    expect(form.children.item(6).children.item(0).innerText).toBe("Go back to login");
+    expect(form.children.item(6).children.item(0).href).toBe(
       new URL("/login", location.href).toString(),
     );
   });

--- a/lib/services/core/ui/__tests__/new-password.test.js
+++ b/lib/services/core/ui/__tests__/new-password.test.js
@@ -11,7 +11,22 @@ let props;
 beforeEach(() => {
   jest.resetAllMocks();
 
-  props = {};
+  props = {
+    fields: [
+      {
+        "@id": "password",
+        "@type": "input",
+        autocomplete: true,
+        hint: "password",
+        maxlength: 128,
+        minlength: 8,
+        pattern: "^.{8,128}$",
+        placeholder: "password",
+        required: true,
+        "~ord": 0,
+      },
+    ],
+  };
 
   wrapUI.mockImplementation((el) => {
     const wrapper = document.createElement("div");
@@ -55,6 +70,7 @@ describe("when no custom labels are used", () => {
       expect(passwordCheckLabel.innerText).toBe("Confirm new password");
       expect(passwordCheckInput.autofocus).toBe(false);
       expect(passwordCheckInput.id).toBe("IKUISDK-confirm-new-password");
+      expect(passwordContainer.childElementCount).toBe(3);
 
       const submitButton = passwordContainer.querySelector(
         "button[id='IKUISDK-btn-new-password']",
@@ -202,6 +218,66 @@ describe("when no custom labels are used", () => {
       });
     });
   });
+
+  describe("when there is an unknown field", () => {
+    /**
+     * @type {HTMLElement}
+     */
+    let returnedValue;
+
+    beforeEach(() => {
+      props.fields.push({
+        "@id": "whatever",
+        "@type": "input",
+        autocomplete: true,
+        hint: "some-hint",
+        maxlength: 128,
+        minlength: 8,
+        pattern: "^.{8,128}$",
+        placeholder: "custom-placeholder",
+        required: true,
+        "~ord": 1,
+      });
+
+      returnedValue = newPasswordUI(props);
+    });
+
+    it("returns correct value", () => {
+      expect(returnedValue.className).toBe("mocked-wrapper");
+
+      const passwordContainer = returnedValue.querySelector(
+        "div[id='IKUISDK-new-password-container']",
+      );
+      const formGroups = passwordContainer.getElementsByClassName("form-group");
+      const passwordFormGroup = formGroups[0];
+      const passwordLabel = passwordFormGroup.getElementsByTagName("label")[0];
+      const passwordInput = passwordFormGroup.getElementsByTagName("input")[0];
+      expect(passwordLabel.htmlFor).toBe("IKUISDK-new-password");
+      expect(passwordLabel.innerText).toBe("New password");
+      expect(passwordInput.autofocus).toBe(true);
+      expect(passwordInput.id).toBe("IKUISDK-new-password");
+      const passwordCheckFormGroup = formGroups[1];
+      const passwordCheckLabel = passwordCheckFormGroup.getElementsByTagName("label")[0];
+      const passwordCheckInput = passwordCheckFormGroup.getElementsByTagName("input")[0];
+      expect(passwordCheckLabel.htmlFor).toBe("IKUISDK-confirm-new-password");
+      expect(passwordCheckLabel.innerText).toBe("Confirm new password");
+      expect(passwordCheckInput.autofocus).toBe(false);
+      expect(passwordCheckInput.id).toBe("IKUISDK-confirm-new-password");
+      expect(passwordContainer.childElementCount).toBe(4);
+      const unknownFieldContainer = passwordContainer.children.item(2);
+      const unknownFieldLabel = unknownFieldContainer.getElementsByTagName("label")[0];
+      const unknownFieldInput = unknownFieldContainer.getElementsByTagName("input")[0];
+      expect(unknownFieldLabel.htmlFor).toBe("whatever");
+      expect(unknownFieldLabel.innerText).toBe("whatever");
+      expect(unknownFieldInput.autofocus).toBe(true);
+      expect(unknownFieldInput.id).toBe("whatever");
+
+      const submitButton = passwordContainer.querySelector(
+        "button[id='IKUISDK-btn-new-password']",
+      );
+      expect(submitButton.innerText).toBe("Reset password");
+    });
+  });
 });
 
 describe("when custom labels are used", () => {
@@ -241,6 +317,7 @@ describe("when custom labels are used", () => {
     expect(passwordCheckLabel.innerText).toBe("Confirm the new password");
     expect(passwordCheckInput.autofocus).toBe(false);
     expect(passwordCheckInput.id).toBe("IKUISDK-confirm-new-password");
+    expect(passwordContainer.childElementCount).toBe(3);
 
     const submitButton = passwordContainer.querySelector("button[id='IKUISDK-btn-new-password']");
     expect(submitButton.innerText).toBe("Submit");

--- a/lib/services/core/ui/components/__tests__/inputs.test.js
+++ b/lib/services/core/ui/components/__tests__/inputs.test.js
@@ -1,0 +1,146 @@
+const { inputWithLabel } = require("../inputs");
+
+let props;
+/**
+ * @type {HTMLElement}
+ */
+let label;
+/**
+ * @type {HTMLElement}
+ */
+let input;
+/**
+ * @type {HTMLElement}
+ */
+let note;
+
+const createElements = (props) => {
+  const result = inputWithLabel(props);
+  label = result.label;
+  input = result.input;
+  note = result.note;
+};
+
+beforeEach(() => {
+  props = {
+    id: "input-id",
+    type: "text",
+  };
+});
+
+describe("when only type and id are set", () => {
+  beforeEach(() => {
+    createElements(props);
+  });
+
+  it("creates an input with the id and type set", () => {
+    expect(input.outerHTML).toBe(
+      '<input id="input-id" type="text" autocomplete="off" style="height: 45px; font-family: \'Raleway\', sans-serif; font-size: 14px; border-radius: 6px; outline: none; width: 100% !important; display: block; color: black; box-sizing: border-box; margin-top: 5px; margin-bottom: 20px; padding: 5px 10px;">',
+    );
+  });
+
+  it("creates a label for the input", () => {
+    expect(label.outerHTML).toBe(
+      '<label style="font-family: \'Raleway\', sans-serif; font-size: 16px; width: 100% !important; display: block; text-transform: capitalize;" for="input-id"></label>',
+    );
+  });
+
+  it("does not create a note", () => {
+    expect(note).toBeUndefined();
+  });
+});
+
+describe("when type, id and label are set", () => {
+  beforeEach(() => {
+    props.labelText = "Custom label";
+    createElements(props);
+  });
+
+  it("creates an input with the id and type set", () => {
+    expect(input.outerHTML).toBe(
+      '<input id="input-id" type="text" autocomplete="off" style="height: 45px; font-family: \'Raleway\', sans-serif; font-size: 14px; border-radius: 6px; outline: none; width: 100% !important; display: block; color: black; box-sizing: border-box; margin-top: 5px; margin-bottom: 20px; padding: 5px 10px;">',
+    );
+  });
+
+  it("creates a label for the input", () => {
+    expect(label.innerText).toBe("Custom label");
+    expect(label.outerHTML).toBe(
+      '<label style="font-family: \'Raleway\', sans-serif; font-size: 16px; width: 100% !important; display: block; text-transform: capitalize;" for="input-id"></label>',
+    );
+  });
+
+  it("does not create a note", () => {
+    expect(note).toBeUndefined();
+  });
+});
+
+describe("when type, id, required and autocomplete are set", () => {
+  beforeEach(() => {
+    props.context = { autocomplete: true, required: true };
+    createElements(props);
+  });
+
+  it("creates an input with the id and type set", () => {
+    expect(input.outerHTML).toBe(
+      '<input id="input-id" type="text" autocomplete="on" style="height: 45px; font-family: \'Raleway\', sans-serif; font-size: 14px; border-radius: 6px; outline: none; width: 100% !important; display: block; color: black; box-sizing: border-box; margin-top: 5px; margin-bottom: 20px; padding: 5px 10px;" required="">',
+    );
+  });
+
+  it("creates a label for the input", () => {
+    expect(label.outerHTML).toBe(
+      '<label style="font-family: \'Raleway\', sans-serif; font-size: 16px; width: 100% !important; display: block; text-transform: capitalize;" for="input-id"></label>',
+    );
+  });
+
+  it("does not create a note", () => {
+    expect(note).toBeUndefined();
+  });
+});
+
+describe("when type, id, minlength, maxlength and pattern are set", () => {
+  beforeEach(() => {
+    props.context = { minlength: 4, maxlength: 8, pattern: "^.{4,8}$" };
+    createElements(props);
+  });
+
+  it("creates an input with the id and type set", () => {
+    expect(input.outerHTML).toBe(
+      '<input id="input-id" type="text" autocomplete="off" style="height: 45px; font-family: \'Raleway\', sans-serif; font-size: 14px; border-radius: 6px; outline: none; width: 100% !important; display: block; color: black; box-sizing: border-box; margin-top: 5px; margin-bottom: 20px; padding: 5px 10px;" minlength="4" maxlength="8" pattern="^.{4,8}$">',
+    );
+  });
+
+  it("creates a label for the input", () => {
+    expect(label.outerHTML).toBe(
+      '<label style="font-family: \'Raleway\', sans-serif; font-size: 16px; width: 100% !important; display: block; text-transform: capitalize;" for="input-id"></label>',
+    );
+  });
+
+  it("does not create a note", () => {
+    expect(note).toBeUndefined();
+  });
+});
+
+describe("when type, id and a note are set", () => {
+  beforeEach(() => {
+    props.noteText = "<i>Some note</i>";
+    createElements(props);
+  });
+
+  it("creates an input with the id and type set", () => {
+    expect(input.outerHTML).toBe(
+      '<input id="input-id" type="text" autocomplete="off" style="height: 45px; font-family: \'Raleway\', sans-serif; font-size: 14px; border-radius: 6px; outline: none; width: 100% !important; display: block; color: black; box-sizing: border-box; margin-top: 5px; margin-bottom: 20px; padding: 5px 10px;">',
+    );
+  });
+
+  it("creates a label for the input", () => {
+    expect(label.outerHTML).toBe(
+      '<label style="font-family: \'Raleway\', sans-serif; font-size: 16px; width: 100% !important; display: block; text-transform: capitalize;" for="input-id"></label>',
+    );
+  });
+
+  it("creates a note", () => {
+    expect(note.outerHTML).toBe(
+      '<div class="note" style="font-size: small; position: relative; top: -16px; padding-bottom: 8px;"><i>Some note</i></div>',
+    );
+  });
+});

--- a/lib/services/core/ui/components/inputs.js
+++ b/lib/services/core/ui/components/inputs.js
@@ -1,4 +1,4 @@
-const inputWithLabel = ({ type, id, labelText, autofocus, autocomplete = "off", noteText }) => {
+const inputWithLabel = ({ type, id, labelText, autofocus, noteText, context }) => {
   const label = document.createElement("label");
   label.style.cssText = `
     font-family: 'Raleway', sans-serif;
@@ -14,7 +14,7 @@ const inputWithLabel = ({ type, id, labelText, autofocus, autocomplete = "off", 
 
   input.id = id;
   input.type = type;
-  input.autocomplete = autocomplete;
+  input.autocomplete = "off";
   input.style.cssText = `
     height: 45px;
     font-family: 'Raleway', sans-serif;
@@ -32,6 +32,24 @@ const inputWithLabel = ({ type, id, labelText, autofocus, autocomplete = "off", 
   `;
   input.autofocus = autofocus;
 
+  if (context) {
+    if (context.required) {
+      input.required = true;
+    }
+    if (context.autocomplete) {
+      input.autocomplete = "on";
+    }
+    if (context.minlength) {
+      input.minLength = context.minlength.toString();
+    }
+    if (context.maxlength) {
+      input.maxLength = context.maxlength.toString();
+    }
+    if (context.pattern) {
+      input.pattern = context.pattern;
+    }
+  }
+
   const note = noteText && document.createElement("div");
   if (note) {
     note.innerHTML = noteText;
@@ -43,6 +61,7 @@ const inputWithLabel = ({ type, id, labelText, autofocus, autocomplete = "off", 
       padding-bottom: 8px;
     `;
   }
+
   return { label, input, note };
 };
 

--- a/lib/services/core/ui/forgot-password.js
+++ b/lib/services/core/ui/forgot-password.js
@@ -20,15 +20,19 @@ const forgotPasswordUI = ({ fields, labels, loginPath = "/login" }) => {
   const forgottenPasswordForm = document.createElement("form");
   forgottenPasswordForm.className = "forgotten-password-form";
 
-  const { label, input } = inputWithLabel({
-    type: "email",
-    id: resetPasswordEmail,
-    labelText: (labels && labels.username) || defaultLabels.username,
-    autofocus: true,
-  });
+  const usernameLabel = (labels && labels.username) || defaultLabels.username;
+  fields.forEach((field) => {
+    const { label, input } = inputWithLabel({
+      type: field["@id"] === "username" ? "email" : "text",
+      id: field["@id"] === "username" ? resetPasswordEmail : field["@id"],
+      labelText: field["@id"] === "username" ? usernameLabel : field["@id"],
+      autofocus: true,
+      context: field,
+    });
 
-  forgottenPasswordForm.appendChild(label);
-  forgottenPasswordForm.appendChild(input);
+    forgottenPasswordForm.appendChild(label);
+    forgottenPasswordForm.appendChild(input);
+  });
 
   const submitBtn = primaryButtonUI({
     id: resetPasswordBtn,

--- a/lib/services/core/ui/messageParser/__tests__/form.test.js
+++ b/lib/services/core/ui/messageParser/__tests__/form.test.js
@@ -184,6 +184,7 @@ describe("when the UI context is 'password#default'", () => {
             labelText: "Username mock",
             autofocus: true,
             noteText: undefined,
+            context: props.context.fields[0],
           });
           expect(createRenderComponentCallback).toBeCalledTimes(2);
           expect(createRenderComponentCallback).nthCalledWith(
@@ -308,6 +309,7 @@ describe("when the UI context is 'password#default'", () => {
             labelText: "Username mock",
             autofocus: true,
             noteText: "User note",
+            context: props.context.fields[0],
           });
           expect(createRenderComponentCallback).toBeCalledTimes(2);
           expect(createRenderComponentCallback).nthCalledWith(
@@ -391,6 +393,7 @@ describe("when the UI context is 'password#default'", () => {
             id: "IKUISDK-username",
             labelText: "Custom username",
             autofocus: true,
+            context: props.context.fields[0],
           });
           expect(createRenderComponentCallback).toBeCalledTimes(2);
           expect(createRenderComponentCallback).nthCalledWith(
@@ -476,6 +479,7 @@ describe("when the UI context is 'password#default'", () => {
             id: "IKUISDK-password",
             labelText: "Password mock",
             noteText: undefined,
+            context: props.context.fields[0],
           });
           expect(createRenderComponentCallback).toBeCalledTimes(2);
           expect(createRenderComponentCallback).nthCalledWith(
@@ -529,6 +533,7 @@ describe("when the UI context is 'password#default'", () => {
             id: "IKUISDK-password",
             labelText: "Password mock",
             noteText: "Password note",
+            context: props.context.fields[0],
           });
           expect(createRenderComponentCallback).toBeCalledTimes(2);
           expect(createRenderComponentCallback).nthCalledWith(
@@ -581,6 +586,7 @@ describe("when the UI context is 'password#default'", () => {
             type: "password",
             id: "IKUISDK-password",
             labelText: "Custom password",
+            context: props.context.fields[0],
           });
           expect(createRenderComponentCallback).toBeCalledTimes(2);
           expect(createRenderComponentCallback).nthCalledWith(
@@ -654,6 +660,7 @@ describe("when the UI context is 'passwordCreate#default'", () => {
               labelText: "Username mock",
               autofocus: true,
               noteText: undefined,
+              context: props.context.fields[0],
             });
             expect(createRenderComponentCallback).toBeCalledTimes(2);
             expect(createRenderComponentCallback).nthCalledWith(
@@ -778,6 +785,7 @@ describe("when the UI context is 'passwordCreate#default'", () => {
               labelText: "Username mock",
               autofocus: true,
               noteText: "User note",
+              context: props.context.fields[0],
             });
             expect(createRenderComponentCallback).toBeCalledTimes(2);
             expect(createRenderComponentCallback).nthCalledWith(
@@ -861,6 +869,7 @@ describe("when the UI context is 'passwordCreate#default'", () => {
               id: "IKUISDK-username",
               labelText: "Custom username",
               autofocus: true,
+              context: props.context.fields[0],
             });
             expect(createRenderComponentCallback).toBeCalledTimes(2);
             expect(createRenderComponentCallback).nthCalledWith(
@@ -1032,6 +1041,7 @@ describe("when the UI context is 'passwordCreate#default'", () => {
           labelText: "Username mock",
           autofocus: true,
           noteText: undefined,
+          context: props.context.fields[0],
         });
         expect(createRenderComponentCallback).toBeCalledTimes(3);
         expect(createRenderComponentCallback).nthCalledWith(
@@ -1136,12 +1146,14 @@ describe("when the UI context is 'passwordCreate#default'", () => {
           id: "IKUISDK-password",
           labelText: "Password mock",
           noteText: undefined,
+          context: props.context.fields[0],
         });
         expect(inputWithLabel).nthCalledWith(2, {
           type: "password",
           id: "IKUISDK-confirm-password",
           labelText: "Confirm password mock",
           noteText: undefined,
+          context: props.context.fields[0],
         });
         expect(createRenderComponentCallback).toBeCalledTimes(3);
         expect(createRenderComponentCallback).nthCalledWith(
@@ -1208,12 +1220,14 @@ describe("when the UI context is 'passwordCreate#default'", () => {
           id: "IKUISDK-password",
           labelText: "Password mock",
           noteText: "Password note",
+          context: props.context.fields[0],
         });
         expect(inputWithLabel).nthCalledWith(2, {
           type: "password",
           id: "IKUISDK-confirm-password",
           labelText: "Confirm password mock",
           noteText: "Password check note",
+          context: props.context.fields[0],
         });
         expect(createRenderComponentCallback).toBeCalledTimes(3);
         expect(createRenderComponentCallback).nthCalledWith(
@@ -1278,11 +1292,13 @@ describe("when the UI context is 'passwordCreate#default'", () => {
           type: "password",
           id: "IKUISDK-password",
           labelText: "Custom password",
+          context: props.context.fields[0],
         });
         expect(inputWithLabel).nthCalledWith(2, {
           type: "password",
           id: "IKUISDK-confirm-password",
           labelText: "Custom confirm password",
+          context: props.context.fields[0],
         });
         expect(createRenderComponentCallback).toBeCalledTimes(3);
         expect(createRenderComponentCallback).nthCalledWith(
@@ -1359,6 +1375,7 @@ describe("when the UI context is 'passwordCreate' (without scope)", () => {
         labelText: "Username mock",
         autofocus: true,
         noteText: undefined,
+        context: props.context.fields[0],
       });
       expect(createRenderComponentCallback).toBeCalledTimes(2);
       expect(createRenderComponentCallback).nthCalledWith(
@@ -1452,6 +1469,7 @@ describe("when the UI context is 'forgottenPassword#default'", () => {
             labelText: "Email mock",
             autofocus: true,
             noteText: undefined,
+            context: props.context.fields[0],
           });
           expect(createRenderComponentCallback).toBeCalledTimes(2);
           expect(createRenderComponentCallback).nthCalledWith(
@@ -1554,6 +1572,7 @@ describe("when the UI context is 'forgottenPassword#default'", () => {
             labelText: "Email mock",
             autofocus: true,
             noteText: "User note",
+            context: props.context.fields[0],
           });
           expect(createRenderComponentCallback).toBeCalledTimes(2);
           expect(createRenderComponentCallback).nthCalledWith(
@@ -1633,6 +1652,7 @@ describe("when the UI context is 'forgottenPassword#default'", () => {
             id: "IKUISDK-reset-password-email",
             labelText: "Custom email",
             autofocus: true,
+            context: props.context.fields[0],
           });
           expect(createRenderComponentCallback).toBeCalledTimes(2);
           expect(createRenderComponentCallback).nthCalledWith(

--- a/lib/services/core/ui/messageParser/form.js
+++ b/lib/services/core/ui/messageParser/form.js
@@ -96,6 +96,7 @@ const form = ({
           labelText,
           autofocus: true,
           noteText: userNoteText,
+          context: formField,
         });
         const userEl = document.createElement("div");
         userEl.appendChild(userLabel);
@@ -122,6 +123,7 @@ const form = ({
           id: elementIds.inputPassword,
           labelText,
           noteText: passwordNoteText,
+          context: formField,
         });
         const psswrdEl = document.createElement("div");
         psswrdEl.appendChild(psswrdLabel);
@@ -151,6 +153,7 @@ const form = ({
             id: elementIds.inputConfirmPassword,
             labelText: psswrdConfirmlabelText,
             noteText: passwordCheckNoteText,
+            context: formField,
           });
           const psswrdConfirmEl = document.createElement("div");
           psswrdConfirmEl.appendChild(psswrdConfirmLabel);

--- a/lib/services/core/ui/new-password.js
+++ b/lib/services/core/ui/new-password.js
@@ -7,7 +7,7 @@ const { getElementIds } = require("../lib/config");
 
 const elementIds = getElementIds();
 
-const newPasswordUI = ({ labels, validatePassword }) => {
+const newPasswordUI = ({ fields, labels, validatePassword }) => {
   const defaultLabels = {
     newPassword: getLocalizedMessage("uisdk.new_password.password"),
     confirmNewPassword: getLocalizedMessage("uisdk.new_password.confirm_password"),
@@ -17,26 +17,50 @@ const newPasswordUI = ({ labels, validatePassword }) => {
   const newPasswordContainer = document.createElement("div");
   newPasswordContainer.id = elementIds.newPasswordContainer;
 
-  const passwordContainer = document.createElement("div");
-  passwordContainer.className = "form-group";
-  const { label: passwrdLabel, input: passwrdInput } = inputWithLabel({
-    type: "password",
-    id: elementIds.inputNewPassword,
-    labelText: (labels && labels.newPassword) || defaultLabels.newPassword,
-    autofocus: true,
-  });
-  passwordContainer.appendChild(passwrdLabel);
-  passwordContainer.appendChild(passwrdInput);
+  let passwrdConfirmInput;
+  fields.forEach((field) => {
+    if (field["@id"] === "password") {
+      const passwordContainer = document.createElement("div");
+      passwordContainer.className = "form-group";
+      const { label: passwrdLabel, input: passwrdInput } = inputWithLabel({
+        type: "password",
+        id: elementIds.inputNewPassword,
+        labelText: (labels && labels.newPassword) || defaultLabels.newPassword,
+        autofocus: true,
+        context: field,
+      });
+      passwordContainer.appendChild(passwrdLabel);
+      passwordContainer.appendChild(passwrdInput);
 
-  const passwordConfirmContainer = document.createElement("div");
-  passwordConfirmContainer.className = "form-group";
-  const { label: passwrdConfirmLabel, input: passwrdConfirmInput } = inputWithLabel({
-    type: "password",
-    id: elementIds.inputConfirmNewPassword,
-    labelText: (labels && labels.confirmNewPassword) || defaultLabels.confirmNewPassword,
+      const passwordConfirmContainer = document.createElement("div");
+      passwordConfirmContainer.className = "form-group";
+      const passwrdComponents = inputWithLabel({
+        type: "password",
+        id: elementIds.inputConfirmNewPassword,
+        labelText: (labels && labels.confirmNewPassword) || defaultLabels.confirmNewPassword,
+        context: field,
+      });
+      const { label: passwrdConfirmLabel } = passwrdComponents;
+      passwrdConfirmInput = passwrdComponents.input;
+      passwordConfirmContainer.appendChild(passwrdConfirmLabel);
+      passwordConfirmContainer.appendChild(passwrdConfirmInput);
+
+      newPasswordContainer.appendChild(passwordContainer);
+      newPasswordContainer.appendChild(passwordConfirmContainer);
+    } else {
+      const container = document.createElement("div");
+      const { label, input } = inputWithLabel({
+        type: "text",
+        id: field["@id"],
+        labelText: field["@id"],
+        autofocus: true,
+        context: field,
+      });
+      container.appendChild(label);
+      container.appendChild(input);
+      newPasswordContainer.appendChild(container);
+    }
   });
-  passwordConfirmContainer.appendChild(passwrdConfirmLabel);
-  passwordConfirmContainer.appendChild(passwrdConfirmInput);
 
   const submitBtn = primaryButtonUI({
     id: elementIds.submitNewPasswordBtn,
@@ -60,8 +84,6 @@ const newPasswordUI = ({ labels, validatePassword }) => {
     label: (labels && labels.submitButton) || defaultLabels.submitButton,
   });
 
-  newPasswordContainer.appendChild(passwordContainer);
-  newPasswordContainer.appendChild(passwordConfirmContainer);
   newPasswordContainer.appendChild(submitBtn);
 
   return wrapUI(newPasswordContainer);


### PR DESCRIPTION
Input fields now can have attributes like minlength, maxlength,
autocomplete and pattern.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->

# Description

<!-- Please provide a description of the change here. -->

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

# Checklist

- [ ] `make test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](./doc/guides/commit-message.md#commit-message-guidelines)

## CHANGELOG

<!-- Please provide a brief description of changes here. -->
<!-- - [FIX] Fix a dirty bug -->

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
