### PR TITLE
Add a support for custom action labels

### DIFF
--- a/lib/services/core/exports/IKUICore/renderForm.js
+++ b/lib/services/core/exports/IKUICore/renderForm.js
@@ -16,6 +16,7 @@ const refreshUiScreen = (props, renderElement, response) => {
   updateParentElement({
     parent: renderElement,
     child: renderer({
+      actionLabels: props.actionLabels,
       context: response,
       forgotPasswordPath: props.forgotPasswordPath,
       labels: props.labels,
@@ -81,6 +82,7 @@ const refreshUiScreen = (props, renderElement, response) => {
  * @param {HTMLString} [props.passwordInputNote] Add a note under the password input field. This configuration is temporary only and will be removed in the future!
  * @param {HTMLString} [props.passwordCheckInputNote] Add a note under the password check input field. This configuration is temporary only and will be removed in the future!
  * @param {string} [props.otpToken] You can use this property in case you have either email verification or invitation token.
+ * @param {Record<string, string>} [props.actionLabels] You can use this property to replace the values you have used on the indykite.id platform in the auth flow builder.
  */
 const renderForm = (props) => {
   throttleChecker("render");

--- a/lib/services/core/index.d.ts
+++ b/lib/services/core/index.d.ts
@@ -195,6 +195,7 @@ type renderForm = (props: {
     [optionId: string]: string;
   };
   otpToken?: string;
+  actionLabels?: Record<string, string>;
 }) => void;
 
 type renderForgotPasswordForm = (props: {

--- a/lib/services/core/ui/messageParserNew/__tests__/action.test.js
+++ b/lib/services/core/ui/messageParserNew/__tests__/action.test.js
@@ -59,13 +59,115 @@ describe("when context contains 'register' option", () => {
         {
           hint: "register",
           icon: "register-icon",
-          locale_key: "Create a new account",
+          locale_key: "CREATE_ACCOUNT",
         },
       ],
     };
   });
 
-  describe("when no non-required props are used", () => {
+  describe("when actionLabels property is present", () => {
+    beforeEach(() => {
+      props.actionLabels = {
+        CREATE_ACCOUNT: "Create a new account",
+      };
+    });
+
+    describe("when no non-required props are used", () => {
+      beforeEach(() => {
+        action(props);
+      });
+
+      it("adds an element to the container", () => {
+        expect(props.htmlContainer.children.length).toBeGreaterThan(0);
+      });
+
+      it("calls createRenderComponentCallback with correct arguments", () => {
+        expect(createRenderComponentCallback).toBeCalledTimes(1);
+        expect(navButtonUI).toBeCalledTimes(1);
+        expect(createRenderComponentCallback).toBeCalledWith(
+          undefined,
+          navButtonUI.mock.results[0].value,
+          "action",
+          "register",
+          "Create a new account",
+        );
+      });
+
+      it("creates the navigation button", () => {
+        expect(navButtonUI).toBeCalledTimes(1);
+        expect(navButtonUI).toBeCalledWith({
+          id: "IKUISDK-btn-action-register",
+          label: "Create a new account",
+          onClick: expect.any(Function),
+        });
+      });
+
+      describe("when the button is clicked", () => {
+        describe("when the action is handled successfully", () => {
+          const handleActionResponse = {
+            "~thread": {
+              thid: "thread-id",
+            },
+            "@type": "oidc",
+            prv: "indykite.me",
+          };
+
+          beforeEach(() => {
+            handleAction.mockImplementation(() => handleActionResponse);
+
+            return navButtonUI.mock.calls[0][0].onClick();
+          });
+
+          it("handles action with correct arguments", () => {
+            expect(handleAction).toBeCalledTimes(1);
+            expect(handleAction).toBeCalledWith({
+              id: "action-id",
+              action: "register",
+            });
+          });
+
+          it("calls success callback with the response", () => {
+            expect(props.onSuccessCallback).toBeCalledTimes(1);
+            expect(props.onSuccessCallback).toBeCalledWith(handleActionResponse);
+          });
+
+          it("does not call fail callback", () => {
+            expect(props.onFailCallback).toBeCalledTimes(0);
+          });
+
+          it("does not print any errors to the console", () => {
+            expect(console.error).toBeCalledTimes(0);
+          });
+        });
+
+        describe("when the action handler throws an error", () => {
+          const error = new Error("Test error");
+
+          beforeEach(() => {
+            handleAction.mockImplementation(() => Promise.reject(error));
+
+            return navButtonUI.mock.calls[0][0].onClick();
+          });
+
+          it("does not call success callback", () => {
+            expect(props.onSuccessCallback).toBeCalledTimes(0);
+          });
+
+          it("calls the fail callback", () => {
+            expect(props.onFailCallback).toBeCalledTimes(1);
+            expect(props.onFailCallback).toBeCalledWith(error);
+          });
+
+          it("prints the error to the console", () => {
+            expect(console.error).toBeCalledTimes(1);
+            expect(console.error).toBeCalledWith(error);
+          });
+        });
+      });
+    });
+  });
+
+  describe("when actionLabels property is not present", () => {
     beforeEach(() => {
       action(props);
     });
@@ -82,7 +184,7 @@ describe("when context contains 'register' option", () => {
         navButtonUI.mock.results[0].value,
         "action",
         "register",
-        "Create a new account",
+        "CREATE_ACCOUNT",
       );
     });
 
@@ -90,71 +192,8 @@ describe("when context contains 'register' option", () => {
       expect(navButtonUI).toBeCalledTimes(1);
       expect(navButtonUI).toBeCalledWith({
         id: "IKUISDK-btn-action-register",
-        label: "Create a new account",
+        label: "CREATE_ACCOUNT",
         onClick: expect.any(Function),
-      });
-    });
-
-    describe("when the button is clicked", () => {
-      describe("when the action is handled successfully", () => {
-        const handleActionResponse = {
-          "~thread": {
-            thid: "thread-id",
-          },
-          "@type": "oidc",
-          prv: "indykite.me",
-        };
-
-        beforeEach(() => {
-          handleAction.mockImplementation(() => handleActionResponse);
-
-          return navButtonUI.mock.calls[0][0].onClick();
-        });
-
-        it("handles action with correct arguments", () => {
-          expect(handleAction).toBeCalledTimes(1);
-          expect(handleAction).toBeCalledWith({
-            id: "action-id",
-            action: "register",
-          });
-        });
-
-        it("calls success callback with the response", () => {
-          expect(props.onSuccessCallback).toBeCalledTimes(1);
-          expect(props.onSuccessCallback).toBeCalledWith(handleActionResponse);
-        });
-
-        it("does not call fail callback", () => {
-          expect(props.onFailCallback).toBeCalledTimes(0);
-        });
-
-        it("does not print any errors to the console", () => {
-          expect(console.error).toBeCalledTimes(0);
-        });
-      });
-
-      describe("when the action handler throws an error", () => {
-        const error = new Error("Test error");
-
-        beforeEach(() => {
-          handleAction.mockImplementation(() => Promise.reject(error));
-
-          return navButtonUI.mock.calls[0][0].onClick();
-        });
-
-        it("does not call success callback", () => {
-          expect(props.onSuccessCallback).toBeCalledTimes(0);
-        });
-
-        it("calls the fail callback", () => {
-          expect(props.onFailCallback).toBeCalledTimes(1);
-          expect(props.onFailCallback).toBeCalledWith(error);
-        });
-
-        it("prints the error to the console", () => {
-          expect(console.error).toBeCalledTimes(1);
-          expect(console.error).toBeCalledWith(error);
-        });
       });
     });
   });

--- a/lib/services/core/ui/messageParserNew/action.js
+++ b/lib/services/core/ui/messageParserNew/action.js
@@ -29,6 +29,7 @@ const { navButtonUI } = require("../components/buttons");
  * }} arguments
  */
 const action = ({
+  actionLabels = {},
   context = {},
   htmlContainer,
   onFailCallback,
@@ -52,7 +53,8 @@ const action = ({
       }
     };
 
-    const buttonLabel = actionOption.locale_key;
+    const localeKey = actionOption.locale_key;
+    const buttonLabel = actionLabels[localeKey] || localeKey;
     const buttonId = `${elementIds.btnPrefix}-action-${actionOption.hint}`;
     const actionName = actionOption.hint;
 

--- a/lib/services/core/ui/renderer.js
+++ b/lib/services/core/ui/renderer.js
@@ -5,6 +5,7 @@ const messageParser = require("./messageParser");
 const messageParserNew = require("./messageParserNew");
 
 const renderer = ({
+  actionLabels,
   context,
   forgotPasswordPath,
   formContainerClassName,
@@ -64,6 +65,7 @@ const renderer = ({
   const parser = useNewVersion ? messageParserNew : messageParser;
 
   parser({
+    actionLabels,
     context,
     htmlContainer: formContainer,
     labels,


### PR DESCRIPTION
This PR allows to define custom translations of action locale keys used in the Action node in the auth flow builder.
```ts
IKUICore.renderForm({
  /* ... */
  actionLabels: {
    KEY_REGISTER: "Registration",
    KEY_FORGOTTEN: "Forgotten password?",
  }
});
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->

# Description

<!-- Please provide a description of the change here. -->

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

# Checklist

- [ ] `make test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](./doc/guides/commit-message.md#commit-message-guidelines)

## CHANGELOG

<!-- Please provide a brief description of changes here. -->
<!-- - [FIX] Fix a dirty bug -->

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
