### PR TITLE
Check if password pairs match

### DIFF
--- a/lib/services/core/lib/common/__tests__/handleForm.test.js
+++ b/lib/services/core/lib/common/__tests__/handleForm.test.js
@@ -16,6 +16,17 @@ jest.mock("../../config", () => {
 jest.mock("../../notifications");
 jest.mock("../../../utils/helpers");
 
+beforeAll(() => {
+  window.IKSDK = {
+    config: {
+      localeConfig: {
+        locale: "en-US",
+        messages: {},
+      },
+    },
+  };
+});
+
 beforeEach(() => {
   jest.clearAllMocks();
 
@@ -132,6 +143,93 @@ describe("when jarvis returns correct data", () => {
         "@type": "verifier",
       });
     });
+  });
+});
+
+describe("when not all inputs pairs (e.g. password check) match", () => {
+  let caughtError;
+
+  const formFields = [
+    {
+      "@type": "input",
+      "@id": "first",
+    },
+    {
+      "@type": "input",
+      "@id": "second",
+    },
+    {
+      "@type": "input",
+      "@id": "third",
+    },
+    {
+      "@type": "input",
+      "@id": "fourth",
+    },
+  ];
+  const formContext = {
+    "@id": "mocked-context",
+    fields: formFields,
+  };
+  const formId = "mocked-form-id";
+
+  beforeEach(async () => {
+    sendRequest.mockImplementation(() => {
+      return Promise.resolve({
+        data: {
+          "~thread": {
+            thid: "mocked-new-thread-id",
+          },
+          "@type": "verifier",
+        },
+      });
+    });
+
+    jest.spyOn(document, "getElementById").mockImplementation(() => {
+      const formEl = document.createElement("form");
+      formEl.id = formId;
+      const firstInput = document.createElement("input");
+      firstInput.id = `IKUISDK-input-first`;
+      firstInput.value = "123";
+      const secondInput = document.createElement("input");
+      secondInput.id = `IKUISDK-input-second`;
+      secondInput.value = "456";
+      const thirdInput = document.createElement("input");
+      thirdInput.id = `IKUISDK-input-third`;
+      thirdInput.value = "passw0rd";
+      const fourthInput = document.createElement("input");
+      fourthInput.id = `IKUISDK-input-fourth`;
+      fourthInput.value = "passw0rd";
+      formEl.append(firstInput, secondInput, thirdInput, fourthInput);
+      return formEl;
+    });
+
+    const passwordMatchPairIds = [
+      ["IKUISDK-input-first", "IKUISDK-input-second"],
+      ["IKUISDK-input-third", "IKUISDK-input-fourth"],
+    ];
+
+    try {
+      await handleForm({ formContext, formId, passwordMatchPairIds });
+    } catch (err) {
+      caughtError = err;
+    }
+  });
+
+  afterEach(() => {
+    document.getElementById.mockRestore();
+  });
+
+  it("throws an error", () => {
+    expect(caughtError).toEqual(new Error("Password confirmation failed."));
+  });
+
+  it("does not send a request", () => {
+    expect(sendRequest).toBeCalledTimes(0);
+  });
+
+  it("does not set a new thread id", () => {
+    expect(storage.setThreadId).toBeCalledTimes(0);
   });
 });
 

--- a/lib/services/core/lib/common/handleForm.js
+++ b/lib/services/core/lib/common/handleForm.js
@@ -2,8 +2,14 @@ const storage = require("../storage");
 const { cleanError } = require("../notifications");
 const { getElementIds, getBaseUri, getApplicationId } = require("../config");
 const { sendRequest } = require("../../utils/helpers");
+const { getLocalizedMessage } = require("../locale-provider");
 
-const handleForm = async ({ onSuccessCallback, formContext, formId }) => {
+const handleForm = async ({
+  onSuccessCallback,
+  formContext,
+  formId,
+  passwordMatchPairIds = [],
+}) => {
   cleanError();
 
   try {
@@ -21,6 +27,21 @@ const handleForm = async ({ onSuccessCallback, formContext, formId }) => {
       );
       inputValues[field["@id"]] = (inputEl || {}).value;
     });
+
+    const passwordMatches = passwordMatchPairIds.reduce((matches, [fieldId1, fieldId2]) => {
+      if (!matches) return false;
+      const input1 = formEl.querySelector(`input[id="${fieldId1}"]`);
+      const input2 = formEl.querySelector(`input[id="${fieldId2}"]`);
+      const input1Value = (input1 || {}).value;
+      const input2Value = (input2 || {}).value;
+
+      return input1Value === input2Value;
+    }, true);
+
+    if (!passwordMatches) {
+      const message = getLocalizedMessage("uisd.register.password_confirmation_failed");
+      throw new Error(message);
+    }
 
     const response = await sendRequest(
       url,

--- a/lib/services/core/ui/messageParserNew/__tests__/form.test.js
+++ b/lib/services/core/ui/messageParserNew/__tests__/form.test.js
@@ -147,6 +147,7 @@ describe("when the UI context is 'password#default'", () => {
           formContext: props.context,
           formId: `IKUISDK-form-${mockedRandomFormId}`,
           onSuccessCallback: expect.any(Function),
+          passwordMatchPairIds: [],
         });
       });
 
@@ -294,6 +295,7 @@ describe("when the UI context is 'password#default'", () => {
               formContext: props.context,
               formId: `IKUISDK-form-${mockedRandomFormId}`,
               onSuccessCallback: expect.any(Function),
+              passwordMatchPairIds: [],
             });
           });
 
@@ -456,6 +458,7 @@ describe("when the UI context is 'passwordCreate#default'", () => {
           formContext: props.context,
           formId: `IKUISDK-form-${mockedRandomFormId}`,
           onSuccessCallback: expect.any(Function),
+          passwordMatchPairIds: [],
         });
       });
 
@@ -639,6 +642,7 @@ describe("when the UI context is 'passwordCreate#default'", () => {
             formContext: props.context,
             formId: `IKUISDK-form-${mockedRandomFormId}`,
             onSuccessCallback: expect.any(Function),
+            passwordMatchPairIds: [["IKUISDK-input-password", "IKUISDK-input-password-confirm"]],
           });
         });
 
@@ -789,6 +793,7 @@ describe("when the UI context is 'forgottenPassword#default'", () => {
               formContext: props.context,
               formId: `IKUISDK-form-${mockedRandomFormId}`,
               onSuccessCallback: expect.any(Function),
+              passwordMatchPairIds: [],
             });
           });
 
@@ -824,6 +829,7 @@ describe("when the UI context is 'forgottenPassword#default'", () => {
               formContext: props.context,
               formId: `IKUISDK-form-${mockedRandomFormId}`,
               onSuccessCallback: expect.any(Function),
+              passwordMatchPairIds: [],
             });
           });
 
@@ -965,6 +971,7 @@ describe("when the UI context is 'changePassword#default'", () => {
           formContext: props.context,
           formId: `IKUISDK-form-${mockedRandomFormId}`,
           onSuccessCallback: expect.any(Function),
+          passwordMatchPairIds: [],
         });
       });
 
@@ -1148,6 +1155,7 @@ describe("when the UI context is 'changePassword#default'", () => {
             formContext: props.context,
             formId: `IKUISDK-form-${mockedRandomFormId}`,
             onSuccessCallback: expect.any(Function),
+            passwordMatchPairIds: [["IKUISDK-input-password", "IKUISDK-input-password-confirm"]],
           });
         });
 

--- a/lib/services/core/ui/messageParserNew/form.js
+++ b/lib/services/core/ui/messageParserNew/form.js
@@ -122,6 +122,7 @@ const form = ({
   const isRegistration = uiContext === "passwordCreate";
   const isResetPassword = uiContext === "forgottenPassword";
   const isSetNewPassword = uiContext === "changePassword";
+  const passwordMatchPairIds = [];
 
   (context.fields || []).forEach((formField) => {
     const labelText = getInputLabel(
@@ -183,6 +184,11 @@ const form = ({
             context,
           ),
         );
+
+        passwordMatchPairIds.push([
+          `${elementIds.inputPrefix}-${formField["@id"]}`,
+          `${elementIds.inputPrefix}-${formField["@id"]}-confirm`,
+        ]);
       }
     }
   });
@@ -200,9 +206,12 @@ const form = ({
         }
         onSuccessCallback(response);
       },
+      passwordMatchPairIds,
     }).catch((err) => {
       if (typeof err === "object" && err["~error"]) {
         handleError(err["~error"]);
+      } else {
+        handleError({ msg: (err || {}).message });
       }
     });
   };


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->

# Description

In the past I have improved the way how forms are rendered. They are not tight to each UI context but they are rendered according to what `form` object is returned from Jarvis. Anyway, if the SDK is asked to render a registration form, the response contains only one password field, but we want to render two - one for password check. And these two passwords were not checked if they match. This fix adds this check.

<!-- Please provide a description of the change here. -->

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

# Checklist

- [ ] `make test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](./doc/guides/commit-message.md#commit-message-guidelines)

## CHANGELOG

<!-- Please provide a brief description of changes here. -->
<!-- - [FIX] Fix a dirty bug -->

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
