### PR TITLE
Redirect to OIDC provider directly when the URL is known

### DIFF
--- a/lib/services/core/lib/login/__tests__/oidcSetup.test.js
+++ b/lib/services/core/lib/login/__tests__/oidcSetup.test.js
@@ -1,8 +1,4 @@
-const {
-  getOidcFinalUrlWithLoginVerifier,
-  sendRequest,
-  generateRedirectUri,
-} = require("../../../utils/helpers");
+const { sendRequest, generateRedirectUri } = require("../../../utils/helpers");
 const storage = require("../../storage");
 const { getBaseAuthUrl } = require("../../config");
 const singleOidcSetup = require("../singleOidcSetup");
@@ -14,6 +10,18 @@ jest.mock("../../config");
 jest.mock("../singleOidcSetup");
 
 const mockedAuthUrl = "https://example.com/auth/123";
+
+let originalLocation = window.location;
+
+beforeEach(() => {
+  delete window.location;
+  window.location = {};
+  jest.resetAllMocks();
+});
+
+afterEach(() => {
+  window.location = originalLocation;
+});
 
 beforeEach(() => {
   jest.resetAllMocks();
@@ -27,9 +35,196 @@ afterEach(() => {
   console.error.mockRestore();
 });
 
-describe("when parameters are passed as an object", () => {
-  let returnedValue;
+describe("when OIDC URL is not specified", () => {
+  describe("when parameters are passed as an object", () => {
+    let returnedValue;
 
+    describe("when no parameters are specified", () => {
+      const response = {
+        data: {
+          "@type": "oidc",
+          name: "slugworth",
+        },
+      };
+
+      beforeEach(async () => {
+        sendRequest.mockImplementation(() => response);
+
+        returnedValue = await oidcSetup({});
+      });
+
+      it("sends a correct request", () => {
+        expect(sendRequest).toBeCalledTimes(1);
+        expect(sendRequest.mock.calls[0]).toEqual([
+          mockedAuthUrl,
+          "POST",
+          {
+            "@type": "oidc",
+            "~thread": {
+              thid: "stored-thread-id",
+            },
+          },
+          {
+            actionName: "oidc-setup",
+          },
+        ]);
+      });
+
+      it("calls single OIDC setup", () => {
+        expect(singleOidcSetup).toBeCalledTimes(1);
+        expect(singleOidcSetup.mock.calls[0]).toEqual([response.data]);
+      });
+    });
+
+    describe("when all parameters are specified", () => {
+      const response = {
+        data: {
+          "@type": "oidc",
+          name: "slugworth",
+        },
+      };
+
+      beforeEach(async () => {
+        sendRequest.mockImplementation(() => response);
+
+        returnedValue = await oidcSetup({
+          id: "555",
+          redirectUri: "https://redirect.to",
+          loginApp: "my-app",
+          threadId: "custom-thread-id",
+        });
+      });
+
+      it("sends a correct request", () => {
+        expect(sendRequest).toBeCalledTimes(1);
+        expect(sendRequest.mock.calls[0]).toEqual([
+          mockedAuthUrl,
+          "POST",
+          {
+            "@type": "oidc",
+            "~thread": {
+              thid: "custom-thread-id",
+            },
+            "@id": "555",
+            redirectUri: "https://redirect.to",
+            params: {
+              login_app: "my-app",
+            },
+          },
+          {
+            actionName: "oidc-setup",
+          },
+        ]);
+      });
+
+      it("calls single OIDC setup", () => {
+        expect(singleOidcSetup).toBeCalledTimes(1);
+        expect(singleOidcSetup.mock.calls[0]).toEqual([response.data]);
+      });
+    });
+
+    describe("when sendRequest throws an error", () => {
+      const error = new Error("Test error");
+
+      beforeEach(async () => {
+        sendRequest.mockImplementation(() => Promise.reject(error));
+
+        await oidcSetup();
+      });
+
+      it("prints the error to the console", () => {
+        expect(console.error).toBeCalledTimes(1);
+        expect(console.error.mock.calls[0]).toEqual([error]);
+      });
+
+      it("does not call single OIDC setup", () => {
+        expect(singleOidcSetup).toBeCalledTimes(0);
+      });
+    });
+  });
+
+  describe("when parameters are passed as arguments", () => {
+    let returnedValue;
+
+    describe("when no parameters are specified", () => {
+      const response = {
+        data: {
+          "@type": "oidc",
+          name: "slugworth",
+        },
+      };
+
+      beforeEach(async () => {
+        sendRequest.mockImplementation(() => response);
+
+        returnedValue = await oidcSetup();
+      });
+
+      it("sends a correct request", () => {
+        expect(sendRequest).toBeCalledTimes(1);
+        expect(sendRequest.mock.calls[0]).toEqual([
+          mockedAuthUrl,
+          "POST",
+          {
+            "@type": "oidc",
+            "~thread": {
+              thid: "stored-thread-id",
+            },
+          },
+          {
+            actionName: "oidc-setup",
+          },
+        ]);
+      });
+
+      it("calls single OIDC setup", () => {
+        expect(singleOidcSetup).toBeCalledTimes(1);
+        expect(singleOidcSetup.mock.calls[0]).toEqual([response.data]);
+      });
+    });
+
+    describe("when all parameters are specified", () => {
+      const response = {
+        data: {
+          "@type": "oidc",
+          name: "slugworth",
+        },
+      };
+
+      beforeEach(async () => {
+        sendRequest.mockImplementation(() => response);
+
+        returnedValue = await oidcSetup("444", "https://redirect.to", "new-thread-id");
+      });
+
+      it("sends a correct request", () => {
+        expect(sendRequest).toBeCalledTimes(1);
+        expect(sendRequest.mock.calls[0]).toEqual([
+          mockedAuthUrl,
+          "POST",
+          {
+            "@type": "oidc",
+            "~thread": {
+              thid: "new-thread-id",
+            },
+            "@id": "444",
+            redirectUri: "https://redirect.to",
+          },
+          {
+            actionName: "oidc-setup",
+          },
+        ]);
+      });
+
+      it("calls single OIDC setup", () => {
+        expect(singleOidcSetup).toBeCalledTimes(1);
+        expect(singleOidcSetup.mock.calls[0]).toEqual([response.data]);
+      });
+    });
+  });
+});
+
+describe("when OIDC URL is specified", () => {
   describe("when no parameters are specified", () => {
     const response = {
       data: {
@@ -41,175 +236,19 @@ describe("when parameters are passed as an object", () => {
     beforeEach(async () => {
       sendRequest.mockImplementation(() => response);
 
-      returnedValue = await oidcSetup({});
+      returnedValue = await oidcSetup({ url: "https://oauth2.example.com" });
     });
 
-    it("sends a correct request", () => {
-      expect(sendRequest).toBeCalledTimes(1);
-      expect(sendRequest.mock.calls[0]).toEqual([
-        mockedAuthUrl,
-        "POST",
-        {
-          "@type": "oidc",
-          "~thread": {
-            thid: "stored-thread-id",
-          },
-        },
-        {
-          actionName: "oidc-setup",
-        },
-      ]);
-    });
-
-    it("calls single OIDC setup", () => {
-      expect(singleOidcSetup).toBeCalledTimes(1);
-      expect(singleOidcSetup.mock.calls[0]).toEqual([response.data]);
-    });
-  });
-
-  describe("when all parameters are specified", () => {
-    const response = {
-      data: {
-        "@type": "oidc",
-        name: "slugworth",
-      },
-    };
-
-    beforeEach(async () => {
-      sendRequest.mockImplementation(() => response);
-
-      returnedValue = await oidcSetup({
-        id: "555",
-        redirectUri: "https://redirect.to",
-        loginApp: "my-app",
-        threadId: "custom-thread-id",
-      });
-    });
-
-    it("sends a correct request", () => {
-      expect(sendRequest).toBeCalledTimes(1);
-      expect(sendRequest.mock.calls[0]).toEqual([
-        mockedAuthUrl,
-        "POST",
-        {
-          "@type": "oidc",
-          "~thread": {
-            thid: "custom-thread-id",
-          },
-          "@id": "555",
-          redirectUri: "https://redirect.to",
-          params: {
-            login_app: "my-app",
-          },
-        },
-        {
-          actionName: "oidc-setup",
-        },
-      ]);
-    });
-
-    it("calls single OIDC setup", () => {
-      expect(singleOidcSetup).toBeCalledTimes(1);
-      expect(singleOidcSetup.mock.calls[0]).toEqual([response.data]);
-    });
-  });
-
-  describe("when sendRequest throws an error", () => {
-    const error = new Error("Test error");
-
-    beforeEach(async () => {
-      sendRequest.mockImplementation(() => Promise.reject(error));
-
-      await oidcSetup();
-    });
-
-    it("prints the error to the console", () => {
-      expect(console.error).toBeCalledTimes(1);
-      expect(console.error.mock.calls[0]).toEqual([error]);
+    it("does not send a request", () => {
+      expect(sendRequest).toBeCalledTimes(0);
     });
 
     it("does not call single OIDC setup", () => {
       expect(singleOidcSetup).toBeCalledTimes(0);
     });
-  });
-});
 
-describe("when parameters are passed as arguments", () => {
-  let returnedValue;
-
-  describe("when no parameters are specified", () => {
-    const response = {
-      data: {
-        "@type": "oidc",
-        name: "slugworth",
-      },
-    };
-
-    beforeEach(async () => {
-      sendRequest.mockImplementation(() => response);
-
-      returnedValue = await oidcSetup();
-    });
-
-    it("sends a correct request", () => {
-      expect(sendRequest).toBeCalledTimes(1);
-      expect(sendRequest.mock.calls[0]).toEqual([
-        mockedAuthUrl,
-        "POST",
-        {
-          "@type": "oidc",
-          "~thread": {
-            thid: "stored-thread-id",
-          },
-        },
-        {
-          actionName: "oidc-setup",
-        },
-      ]);
-    });
-
-    it("calls single OIDC setup", () => {
-      expect(singleOidcSetup).toBeCalledTimes(1);
-      expect(singleOidcSetup.mock.calls[0]).toEqual([response.data]);
-    });
-  });
-
-  describe("when all parameters are specified", () => {
-    const response = {
-      data: {
-        "@type": "oidc",
-        name: "slugworth",
-      },
-    };
-
-    beforeEach(async () => {
-      sendRequest.mockImplementation(() => response);
-
-      returnedValue = await oidcSetup("444", "https://redirect.to", "new-thread-id");
-    });
-
-    it("sends a correct request", () => {
-      expect(sendRequest).toBeCalledTimes(1);
-      expect(sendRequest.mock.calls[0]).toEqual([
-        mockedAuthUrl,
-        "POST",
-        {
-          "@type": "oidc",
-          "~thread": {
-            thid: "new-thread-id",
-          },
-          "@id": "444",
-          redirectUri: "https://redirect.to",
-        },
-        {
-          actionName: "oidc-setup",
-        },
-      ]);
-    });
-
-    it("calls single OIDC setup", () => {
-      expect(singleOidcSetup).toBeCalledTimes(1);
-      expect(singleOidcSetup.mock.calls[0]).toEqual([response.data]);
+    it("redirects to the URL", () => {
+      expect(window.location.href).toBe("https://oauth2.example.com");
     });
   });
 });

--- a/lib/services/core/lib/login/oidcSetup.js
+++ b/lib/services/core/lib/login/oidcSetup.js
@@ -9,6 +9,7 @@ const { getBaseAuthUrl } = require("../config");
  *   redirectUri?: string | null;
  *   threadId?: string | null;
  *   loginApp?: string;
+ *   url?: string;
  * }} OidcSetupOptions
  */
 
@@ -30,7 +31,12 @@ const oidcSetup = async (idOrOptions, redirectUri, threadId = null) => {
 /**
  * @param {OidcSetupOptions} param0
  */
-const oidcSetupWithOptions = async ({ id, redirectUri, threadId, loginApp }) => {
+const oidcSetupWithOptions = async ({ id, redirectUri, threadId, loginApp, url: oidcUrl }) => {
+  if (typeof oidcUrl === "string" && oidcUrl.length > 0) {
+    window.location.href = oidcUrl;
+    return;
+  }
+
   const url = getBaseAuthUrl();
   let data = {
     "~thread": {

--- a/lib/services/core/ui/messageParserNew/__tests__/oidc.test.js
+++ b/lib/services/core/ui/messageParserNew/__tests__/oidc.test.js
@@ -30,7 +30,7 @@ beforeEach(() => {
     context: {
       "@id": "12345",
       prv: "indykite.id",
-      url: "https://example.com",
+      url: "https://example.com/oauth2",
     },
     htmlContainer: document.createElement("div"),
     redirectUri: "https:/address.com/to/redirect",
@@ -94,6 +94,7 @@ describe("when provider has a name", () => {
             expect(oidcSetup).toBeCalledWith({
               id: "12345",
               redirectUri: "https:/address.com/to/redirect",
+              url: "https://example.com/oauth2",
             });
           });
         });
@@ -130,6 +131,7 @@ describe("when provider has a name", () => {
             expect(oidcSetup).toBeCalledWith({
               id: "12345",
               redirectUri: "https:/address.com/to/redirect",
+              url: "https://example.com/oauth2",
             });
           });
         });
@@ -151,6 +153,7 @@ describe("when provider has a name", () => {
           expect(oidcSetup).toBeCalledWith({
             id: "12345",
             redirectUri: "https:/address.com/to/redirect",
+            url: "https://example.com/oauth2",
           });
         });
       });
@@ -206,6 +209,7 @@ describe("when provider has a name", () => {
           id: "12345",
           redirectUri: "https:/address.com/to/redirect",
           loginApp: "custom-app",
+          url: "https://example.com/oauth2",
         });
       });
     });

--- a/lib/services/core/ui/messageParserNew/oidc.js
+++ b/lib/services/core/ui/messageParserNew/oidc.js
@@ -25,7 +25,7 @@ const oidc = ({ context, htmlContainer, onRenderComponent, redirectUri, loginApp
   const elementIds = getElementIds();
   const clickHandler = async () => {
     const id = context["@id"];
-    const params = { id, redirectUri };
+    const params = { id, redirectUri, url: context.url };
     if (loginApp[id]) {
       params.loginApp = loginApp[id];
     }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->

# Description

When you want to log in with an external OIDC provider and the SDK
already knows a URL where you are needed to be redirected, then
there's not necessary to send an additional request to obtain
the URL again.


<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

# Checklist

- [ ] `make test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](./doc/guides/commit-message.md#commit-message-guidelines)

## CHANGELOG

<!-- Please provide a brief description of changes here. -->
<!-- - [FIX] Fix a dirty bug -->

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
